### PR TITLE
Update questions.js

### DIFF
--- a/public/js/questions/questions.js
+++ b/public/js/questions/questions.js
@@ -3549,8 +3549,8 @@ D: -Infinity
   // 153
   {
     question: `
-console.log(10 === [10])
-console.log(10 === [[[[[[[10]]]]]]])
+console.log(10 == [10])
+console.log(10 == [[[[[[[10]]]]]]])
 `,
     answers: `
 A: true true
@@ -3561,7 +3561,7 @@ D: false true
     rightAnswer: `A`,
     explanation: `
 Согласно спецификации приведенные выражения будут преобразованы следующим образом: <br>
-10 === Number([10].valueOf().toString()) // 10 <br>
+10 == Number([10].valueOf().toString()) // 10 <br>
 Поэтому количество скобок не имеет значения.
 `
   },


### PR DESCRIPTION
Ошибка в вопросе. По условию дано строгое равенство `===`, а в ответе и описании подразумевается обычное `==`, при котором и происходит приведение типов.